### PR TITLE
tools.pm: simplify import

### DIFF
--- a/lib/tools.pm
+++ b/lib/tools.pm
@@ -179,7 +179,7 @@ sub parse_meta_json {
 sub import {
   my ( $self, @args ) = @_;
 
-  my $caller = [caller]->[0];
+  my $caller = caller;
 
   my $caller_stash = do {
     no strict 'refs';


### PR DESCRIPTION
`caller` returns the package name in scalar context.
